### PR TITLE
Use correct default in URI.decode_www_form call

### DIFF
--- a/lib/transifex/crud_requests.rb
+++ b/lib/transifex/crud_requests.rb
@@ -17,7 +17,7 @@ module Transifex
 
       def add_param(url, param_name, param_value)
         uri = URI(url)
-        params = URI.decode_www_form(uri.query || []) << [param_name, param_value]
+        params = URI.decode_www_form(uri.query || "") << [param_name, param_value]
         uri.query = URI.encode_www_form(params)
         uri.to_s
       end


### PR DESCRIPTION
`[]` is not valid for `URI.decode_www_form` and fails with:

``` ruby
> URI.decode_www_form([])
NoMethodError: undefined method `ascii_only?' for []:Array
```

Replaced with an empty String.
