### PR TITLE
Allow resource content updates in other formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ project_resource.content.update({:i18n_type => "TXT", :content => 'new_content'}
 With a file:
 
 ```ruby
-project_resource.content.update({:i18n_type => "YAML", :content => 'path/to/your/file.yml'})
+params = {:i18n_type => "YAML", :content => 'path/to/your/file.yml'}
+options = {:trad_from_file => true}
+project_resource.content.update(params, options)
 ```
 
 ### Resource Translations

--- a/lib/transifex/crud_requests.rb
+++ b/lib/transifex/crud_requests.rb
@@ -63,16 +63,18 @@ module Transifex
     module Update
       module InstanceMethods
         def update(params = {}, options = {})      
-          if params.is_a?(Hash) && params[:i18n_type] && params[:i18n_type] != "TXT"
-            case params[:i18n_type]
-            when "YML"
-              params[:content] = YAML::load_file(params[:content]).to_yaml
-            when "KEYVALUEJSON"
-              params[:content] = params[:content].to_json
-            else
-              file = File.open(params[:content], "rb")
-              params[:content] = file.read
-              file.close
+          if params.is_a?(Hash) && params[:i18n_type]
+            unless options[:trad_from_file].nil?
+              case params[:i18n_type]
+              when "YML"
+                params[:content] = YAML::load_file(params[:content]).to_yaml
+              when "KEYVALUEJSON"
+                params[:content] = params[:content].to_json
+              else
+                file = File.open(params[:content], "rb")
+                params[:content] = file.read
+                file.close
+              end
             end
 
             # Deal with accents

--- a/spec/lib/transifex/resource_content_spec.rb
+++ b/spec/lib/transifex/resource_content_spec.rb
@@ -28,18 +28,22 @@ describe Transifex::ResourceComponents::Content do
 
   describe "Update" do
     it "updates a resource using a file" do
+      params = { i18n_type: "YAML", content: get_yaml_source_trad_file_path("eo") }
+      options = { trad_from_file: true }
+
       VCR.use_cassette "resource/update_content_yml" do
-        expect(resource.content.update(i18n_type: "YAML", content: get_yaml_source_trad_file_path("eo")))
+        expect(resource.content.update(params, options))
           .to eq updated_resource_with_file
       end
     end
 
     it "updates a resource using json" do
       json_resource = project.resource("json")
-      content = {test_string: 'test string as json'}
+      params = {i18n_type: "KEYVALUEJSON", content: {test_string: 'test string as json'}}
+      options = { trad_from_file: true }
 
       VCR.use_cassette "resource/update_content_json" do
-        expect(json_resource.content.update(i18n_type: "KEYVALUEJSON", content: content))
+        expect(json_resource.content.update(params, options))
           .to eq updated_resource_with_json
       end
     end


### PR DESCRIPTION
This enables updates in other 'non-official' formats similar to resource content create.
This however has some side effects in that updating with a file now needs to be specified in options.

Linked issue: #8 