### PR TITLE
Fix force encoding error

### DIFF
--- a/lib/transifex/crud_requests.rb
+++ b/lib/transifex/crud_requests.rb
@@ -64,8 +64,8 @@ module Transifex
       module InstanceMethods
         def update(params = {}, options = {})
           if params.is_a?(Hash) && params[:i18n_type]
-            unless options[:trad_from_file].nil?
-              case
+            if options[:trad_from_file]
+              case params[:i18n_type]
               when "YML"
                 params[:content] = YAML::load_file(params[:content]).to_yaml
               else

--- a/lib/transifex/crud_requests.rb
+++ b/lib/transifex/crud_requests.rb
@@ -1,15 +1,15 @@
 module Transifex
   module CrudRequests
-    class << self      
+    class << self
       def generate_url(object, params = {})
         class_name_string = object.class.name.split("::").last.downcase.to_s
         url = ""
         if object.class.respond_to?(:authors)
-          object.class.authors.map{|author| url += "/" + author.to_s + "/" + object.instance_variable_get("@" + author.to_s + "_slug")}                      
-        end          
+          object.class.authors.map{|author| url += "/" + author.to_s + "/" + object.instance_variable_get("@" + author.to_s + "_slug")}
+        end
         url += "/" + class_name_string
         url += "/" + object.instance_variable_get("@" + class_name_string + "_slug") if object.instance_variable_defined?("@" + class_name_string + "_slug")
-        params.each do |param| 
+        params.each do |param|
           url = add_param(url, param[0], param[1])
         end
         url
@@ -26,12 +26,12 @@ module Transifex
     module Fetch
       module InstanceMethods
         def fetch(options = {})
-          url = CrudRequests.generate_url(self, options)  
+          url = CrudRequests.generate_url(self, options)
           Transifex.query_api(:get, url)
         end
       end
       def self.included(receiver)
-        receiver.send(:include, InstanceMethods)                 
+        receiver.send(:include, InstanceMethods)
       end
     end
     module Create
@@ -40,7 +40,7 @@ module Transifex
           missing_keys = self.class::CREATE_REQUIRED_PARAMS - params.keys
           raise MissingParametersError.new(missing_keys) unless (missing_keys == [:repository_url] || missing_keys == [:private]) || missing_keys.empty?
           if params[:repository_url] && !params[:repository_url].empty? && params[:repository_url].match(/^(http|https|ftp):\/\/[a-zA-Z]+\.[a-zA-Z]+\.[a-zA-Z]+/).nil?
-            raise ParametersFormatError.new(:repository_url, "http|https|ftp://x.x.x") 
+            raise ParametersFormatError.new(:repository_url, "http|https|ftp://x.x.x")
           end
           unless options[:trad_from_file].nil?
             if params[:i18n_type] == "YAML"
@@ -54,27 +54,29 @@ module Transifex
           url = CrudRequests.generate_url(self)
           Transifex.query_api(:post, url, params)
         end
-      end    
-       
-      def self.included(receiver)
-        receiver.send(:include, InstanceMethods)                 
       end
-    end    
+
+      def self.included(receiver)
+        receiver.send(:include, InstanceMethods)
+      end
+    end
     module Update
       module InstanceMethods
-        def update(params = {}, options = {})      
+        def update(params = {}, options = {})
           if params.is_a?(Hash) && params[:i18n_type]
             unless options[:trad_from_file].nil?
-              case params[:i18n_type]
+              case
               when "YML"
                 params[:content] = YAML::load_file(params[:content]).to_yaml
-              when "KEYVALUEJSON"
-                params[:content] = params[:content].to_json
               else
                 file = File.open(params[:content], "rb")
                 params[:content] = file.read
                 file.close
               end
+            end
+
+            if params[:i18n_type] == "KEYVALUEJSON"
+              params[:content] = params[:content].to_json
             end
 
             # Deal with accents
@@ -88,20 +90,20 @@ module Transifex
       end
 
       def self.included(receiver)
-        receiver.send(:include, InstanceMethods)                 
+        receiver.send(:include, InstanceMethods)
       end
     end
     module Delete
       module InstanceMethods
-        def delete(params = {}, options = {})          
+        def delete(params = {}, options = {})
           url = CrudRequests.generate_url(self)
           Transifex.query_api(:delete, url, params)
         end
-      end    
-       
-      def self.included(receiver)
-        receiver.send(:include, InstanceMethods)                 
       end
-    end    
-  end  
+
+      def self.included(receiver)
+        receiver.send(:include, InstanceMethods)
+      end
+    end
+  end
 end

--- a/spec/lib/transifex/resource_content_spec.rb
+++ b/spec/lib/transifex/resource_content_spec.rb
@@ -40,10 +40,9 @@ describe Transifex::ResourceComponents::Content do
     it "updates a resource using json" do
       json_resource = project.resource("json")
       params = {i18n_type: "KEYVALUEJSON", content: {test_string: 'test string as json'}}
-      options = { trad_from_file: true }
 
       VCR.use_cassette "resource/update_content_json" do
-        expect(json_resource.content.update(params, options))
+        expect(json_resource.content.update(params))
           .to eq updated_resource_with_json
       end
     end


### PR DESCRIPTION
`KEYVALUEJSON`allows the content to be sent over as json directly in the call, without the need of specifying a file.
The changes introduced here https://github.com/Fred-grais/transifex-interface-ruby/pull/9 weren't considering this and we were getting the following error

```
 NoMethodError: undefined method 'force_encoding' for {<resource_id>=>{<resource content>}}:Hash
```
